### PR TITLE
Use 1.5em line height

### DIFF
--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -221,6 +221,7 @@ $button-size: 1.5rem;
 	counter-reset: captions;
 	@include container;
 	@include clearfix;
+	line-height: 1.5em;
 	clear: both;
 	margin-top: 2em;
 	h1 {


### PR DESCRIPTION
Most pages noways have a line-height of >1em.
Using a line height of 1.5em makes things more readable.

Before:
<img width="904" alt="bildschirmfoto 2016-01-11 um 15 31 54" src="https://cloud.githubusercontent.com/assets/178464/12236196/a794eade-b878-11e5-8b30-154c56953250.png">

After:
<img width="919" alt="bildschirmfoto 2016-01-11 um 15 31 29" src="https://cloud.githubusercontent.com/assets/178464/12236199/aa9f4b34-b878-11e5-80cf-0ef6e09c7c8d.png">
