### PR TITLE
Fix <li> syntax

### DIFF
--- a/_includes/releases.html
+++ b/_includes/releases.html
@@ -3,9 +3,9 @@
   {% for post in posts %}
   <li>
     <a href="{{ post.url }}">
-      <h3 class="title">{{ post.title | replace: '<br/>', '' }}</h3>
-      <div class="desc">{{ post.desc }}</div>
-     </a>
-   </li>
+      {{ post.title | replace: '<br/>', '' }}
+    </a>
+    <div class="desc">{{ post.desc }}</div>
+  </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
The list items appear smaller because they are no longer `h3`.


![screenshot from 2016-01-12 18-25-05](https://cloud.githubusercontent.com/assets/6399679/12271261/798b4a6a-b95a-11e5-91fd-b87ab466462c.png)

[new vs old]