### PR TITLE
Fix excerpts

### DIFF
--- a/_posts/en/posts/2015-12-14-segregated-witness.md
+++ b/_posts/en/posts/2015-12-14-segregated-witness.md
@@ -8,6 +8,7 @@ author: sipa
 related: false
 tags: [scalability]
 version: 1
+excerpt: This is the extended presentation of Segregated Witness by Pieter Wuille.
 ---
 
 This is the extended presentation of Segregated Witness by Pieter Wuille.

--- a/_posts/en/posts/2016-01-13-developer-visualisation-2015.md
+++ b/_posts/en/posts/2016-01-13-developer-visualisation-2015.md
@@ -5,6 +5,7 @@ name: development-visualisation-2015
 title: Core Development Visualisation for 2015
 permalink: /en/2016/01/13/development-visualisation-2015
 version: 1
+excerpt: The following video shows commit activity in the Bitcoin Core repository during 2015.
 ---
 The following video shows commit activity in the [Bitcoin Core repository][repository] during 2015. A full list of code contributors during this period can be found [here][activity].
 


### PR DESCRIPTION
Markdown link don't appear to be rendering with auto excerpts in the `/` or `/bog/`.