### PR TITLE
[Trivial] Travis CI all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
     
-# branch whitelist, only for GitHub Pages
+# Whitelist all branches since gh-pages branch is blacklisted by default
 branches:
   only:
-  - gh-pages     # test the gh-pages branch
+  - /.*/


### PR DESCRIPTION
@btcdrak discovered that Travis CI blacklists the `gh-pages` branch by default, so he added it to the CI whitelist.  Unfortunately, if you use the whitelist at all, no non-whitelisted branches get built (unless you open a PR to a whitelisted branch).

This commit uses Travis's [regex feature](https://docs.travis-ci.com/user/customizing-the-build/#Using-regular-expressions) to whitelist all branches.  I tested it on my GitHub fork and it [seems to work](https://github.com/harding/website/branches).