### PR TITLE
Update 2016-01-13-supported-bips.md

### DIFF
--- a/_posts/en/pages/2016-01-13-supported-bips.md
+++ b/_posts/en/pages/2016-01-13-supported-bips.md
@@ -5,7 +5,7 @@ type: page
 permalink: /en/bips
 share: false
 ---
-Bitcoin Core supports the following [BIPs](https://github.com/bitcoin/bips/blob/master/bip-0001.mediawiki).
+Bitcoin Core 0.12 supports the following [BIPs](https://github.com/bitcoin/bips/blob/master/bip-0001.mediawiki).
 
 | BIP| Title|
 |----|------|


### PR DESCRIPTION
Add Bitcoin Core 0.12 because 0.11 does not support RBF.