### PR TITLE
Updated whitepaper link in about page

### DIFF
--- a/_posts/en/pages/2016-01-01-about.md
+++ b/_posts/en/pages/2016-01-01-about.md
@@ -9,7 +9,7 @@ version: 1
 
 Bitcoin Core is an [open source](https://opensource.org/) project which maintains and releases Bitcoin client software called "Bitcoin Core".
 
-It is a direct descendant of the original Bitcoin software client released by Satoshi Nakamoto after he published the famous [Bitcoin whitepaper](https://bitcoin.org/bitcoin.pdf).
+It is a direct descendant of the original Bitcoin software client released by Satoshi Nakamoto after he published the famous [Bitcoin whitepaper](https://bitcoincore.org/bitcoin.pdf).
 
 Bitcoin Core consists of both "full-node" software for fully validating the blockchain as well as a bitcoin wallet. The project also currently maintains related software such as the cryptography library [libsecp256k1](https://github.com/bitcoin/secp256k1) and others located at [GitHub](https://github.com/bitcoin).
 


### PR DESCRIPTION
The link to the white paper in the about page points to bitcoin.org. It should now point to the local copy of the paper, hosted on bitcoincore.org.